### PR TITLE
fix build error on windows

### DIFF
--- a/ttyname/errors_unix.go
+++ b/ttyname/errors_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package ttyname
 
 import "errors"


### PR DESCRIPTION
```
..\..\go-gnulib\ttyname\errors_windows.go:5: ErrNotTty redeclared in this block
        previous declaration at ..\..\go-gnulib\ttyname\errors_unix.go:7
```
