### PR TITLE
remove Utsname type conversion from int8 to byte

### DIFF
--- a/utmp/utmp_linux.go
+++ b/utmp/utmp_linux.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/EricLagergren/go-gnulib/util"
 	"golang.org/x/sys/unix"
 )
 
@@ -31,7 +30,7 @@ func WriteWtmp(user, id string, pid int32, typ int16, line string) error {
 	if err != nil {
 		return err
 	}
-	_ = copy(u.Host[:], util.Int8ToByte(name.Release[:]))
+	_ = copy(u.Host[:], name.Release[:])
 	return u.UpdWtmp(Wtmpxfile)
 }
 
@@ -49,7 +48,7 @@ func WriteUtmp(user, id string, pid int32, typ int16, line string, oldline *stri
 
 	var name unix.Utsname
 	if err := unix.Uname(&name); err == nil {
-		_ = copy(u.Host[:], util.Int8ToByte(name.Release[:]))
+		_ = copy(u.Host[:], name.Release[:])
 	}
 
 	file, err := Open(UtmpxFile, Writing)


### PR DESCRIPTION
https://github.com/ericlagergren/go-gnulib/issues/4

I tested with a compilation: 

```
$> go version
go version go1.13.1 linux/amd64
$> cd utmp 
$> go build . 
$> echo $? 
0
```


