### PR TITLE
fix getlogin and a typo in utmp

### DIFF
--- a/chdir/chdirlong.go
+++ b/chdir/chdirlong.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/EricLagergren/go-gnulib/ifdef"
+	"github.com/marguerite/go-gnulib/ifdef"
 	"golang.org/x/sys/unix"
 )
 

--- a/cwd/cwd.go
+++ b/cwd/cwd.go
@@ -4,9 +4,9 @@ package cwd
 import (
 	"os"
 
-	"github.com/EricLagergren/go-gnulib/chdir"
-	"github.com/EricLagergren/go-gnulib/util"
-	"github.com/EricLagergren/go-gnulib/ifdef"
+	"github.com/marguerite/go-gnulib/chdir"
+	"github.com/marguerite/go-gnulib/util"
+	"github.com/marguerite/go-gnulib/ifdef"
 
 	"golang.org/x/sys/unix"
 )

--- a/dirent/getdents_unix.go
+++ b/dirent/getdents_unix.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/EricLagergren/go-gnulib/util"
+	"github.com/marguerite/go-gnulib/util"
 )
 
 // Stream mimics C's DIR structure. It's a stream that can be read from

--- a/fd/fdopendir.go
+++ b/fd/fdopendir.go
@@ -4,8 +4,8 @@ package fd
 import (
 	"golang.org/x/sys/unix"
 
-	"github.com/EricLagergren/go-gnulib/cwd"
-	"github.com/EricLagergren/go-gnulib/dirent"
+	"github.com/marguerite/go-gnulib/cwd"
+	"github.com/marguerite/go-gnulib/dirent"
 )
 
 func isExpected(err error) bool {

--- a/fts/declarations.go
+++ b/fts/declarations.go
@@ -34,7 +34,7 @@ package fts
 import (
 	"syscall"
 
-	"github.com/EricLagergren/go-gnulib/dirent"
+	"github.com/marguerite/go-gnulib/dirent"
 	rb "github.com/EricLagergren/ringbuffer"
 )
 

--- a/fts/fts.go
+++ b/fts/fts.go
@@ -37,8 +37,8 @@ import (
 	"sort"
 	"syscall"
 
-	"github.com/EricLagergren/go-gnulib/dirent"
-	"github.com/EricLagergren/go-gnulib/fd"
+	"github.com/marguerite/go-gnulib/dirent"
+	"github.com/marguerite/go-gnulib/fd"
 
 	"golang.org/x/sys/unix"
 

--- a/fts/fts_cycle.go
+++ b/fts/fts_cycle.go
@@ -1,7 +1,7 @@
 package fts
 
 import (
-	"github.com/EricLagergren/go-gnulib/cycle"
+	"github.com/marguerite/go-gnulib/cycle"
 )
 
 type ActiveDir struct {

--- a/login/getlogin.go
+++ b/login/getlogin.go
@@ -20,7 +20,7 @@ func GetLogin() (string, error) {
 	u := new(utmp.Utmp)
 	_ = copy(u.Line[:], []byte(name[5:]))
 
-	file, err := os.Open(utmp.UtmpFile)
+	file, err := utmp.Open(utmp.UtmpxFile, utmp.Reading)
 	if err != nil {
 		return "", err
 	}

--- a/login/getlogin.go
+++ b/login/getlogin.go
@@ -3,8 +3,8 @@ package login
 import (
 	"os"
 
-	"github.com/EricLagergren/go-gnulib/ttyname"
-	"github.com/EricLagergren/go-gnulib/utmp"
+	"github.com/marguerite/go-gnulib/ttyname"
+	"github.com/marguerite/go-gnulib/utmp"
 )
 
 func GetLogin() (string, error) {

--- a/ttyname/ttyname_linux.go
+++ b/ttyname/ttyname_linux.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/EricLagergren/go-gnulib/dirent"
-	"github.com/EricLagergren/go-gnulib/util"
+	"github.com/marguerite/go-gnulib/dirent"
+	"github.com/marguerite/go-gnulib/util"
 
 	"golang.org/x/sys/unix"
 )

--- a/ttyname/ttyname_windows.go
+++ b/ttyname/ttyname_windows.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"syscall"
 
-	k32 "github.com/EricLagergren/go-gnulib/windows"
+	k32 "github.com/marguerite/go-gnulib/windows"
 )
 
 func count(s []byte) int64 {

--- a/utmp/getutent_linux.go
+++ b/utmp/getutent_linux.go
@@ -87,7 +87,7 @@ func (u *Utmp) GetUtLine(file *File) (*Utmp, error) {
 	var nu Utmp
 	for {
 
-		err := binary.Read(file, binary.LittleEndian, nu)
+		err := binary.Read(file, binary.LittleEndian, &nu)
 		if err != nil {
 			if err == io.EOF {
 				break

--- a/utmp/readutmp_linux.go
+++ b/utmp/readutmp_linux.go
@@ -8,7 +8,7 @@ package utmp
 import (
 	"syscall"
 
-	"github.com/EricLagergren/go-gnulib/util"
+	"github.com/marguerite/go-gnulib/util"
 )
 
 // IsDesirable determines whether the Utmp entry is desired by the user who

--- a/utmp/utmp_freebsd.go
+++ b/utmp/utmp_freebsd.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/EricLagergren/go-gnulib/endian"
+	"github.com/marguerite/go-gnulib/endian"
 )
 
 // Order is the current endianness for a system


### PR DESCRIPTION
1. binary.Read(r io.Reader, order ByteOrder, data interface{})
Data must be `a pointer` to a fixed-size value or a slice of fixed-size values
so it's a typo
2. os.Open returns os.File which is not utmp.File, utmp.File has a `lk *unix.Flock_t`.
and there's no `utmp.UtmpFile` but `utmp.UtmpxFile` according to utmp_linux.go
